### PR TITLE
Fixed unicode usage for python 3

### DIFF
--- a/suds/sax/attribute.py
+++ b/suds/sax/attribute.py
@@ -170,7 +170,12 @@ class Attribute:
 
     def __str__(self):
         """ get an xml string representation """
-        return unicode(self).encode('utf-8')
+        n = self.qname()
+        if self.hasText():
+            v = self.value.escape()
+        else:
+            v = self.value
+        return u'%s="%s"' % (n, v)
 
     def __unicode__(self):
         """ get an xml string representation """

--- a/suds/sax/element.py
+++ b/suds/sax/element.py
@@ -941,7 +941,7 @@ class Element:
             'Element (prefix=%s, name=%s)' % (self.prefix, self.name)
 
     def __str__(self):
-        return unicode(self).encode('utf-8')
+        return self.str()
 
     def __unicode__(self):
         return self.str()

--- a/suds/serviceproxy.py
+++ b/suds/serviceproxy.py
@@ -78,7 +78,7 @@ class ServiceProxy(object):
         return str(self.__client__)
 
     def __unicode__(self):
-        return unicode(self.__client__)
+        return str(self.__client__)
 
     def __getattr__(self, name):
         if is_builtin(name):

--- a/suds/wsse.py
+++ b/suds/wsse.py
@@ -140,7 +140,7 @@ class UsernameToken(Token):
             s.append(self.password)
             s.append(Token.sysdate())
             m = md5()
-            m.update(':'.join(s))
+            m.update(':'.join(s).encode("utf-8"))
             self.nonce = m.hexdigest()
         else:
             self.nonce = text

--- a/suds/xsd/schema.py
+++ b/suds/xsd/schema.py
@@ -146,7 +146,10 @@ class SchemaCollection:
         return len(self.children)
 
     def __str__(self):
-        return unicode(self).encode('utf-8')
+        result = ['\nschema collection']
+        for s in self.children:
+            result.append(s.str(1))
+        return '\n'.join(result)
 
     def __unicode__(self):
         result = ['\nschema collection']
@@ -412,7 +415,7 @@ class Schema:
         return myrep.encode('utf-8')
 
     def __str__(self):
-        return unicode(self).encode('utf-8')
+        return self.str()
 
     def __unicode__(self):
         return self.str()

--- a/suds/xsd/sxbuiltin.py
+++ b/suds/xsd/sxbuiltin.py
@@ -22,8 +22,8 @@ XSD I{builtin} schema objects.
 from logging import getLogger
 from suds.compat import basestring
 from suds.xsd.sxbase import XBuiltin
-import suds.sax.date as dt
-import datetime
+from suds.sax.date import *
+import datetime as dt
 
 
 log = getLogger(__name__)
@@ -152,7 +152,7 @@ class XDate(XBuiltin):
             else:
                 return None
         else:
-            if isinstance(value, datetime.date):
+            if isinstance(value, dt.date):
                 return str(dt.Date(value))
             else:
                 return value
@@ -170,7 +170,7 @@ class XTime(XBuiltin):
             else:
                 return None
         else:
-            if isinstance(value, datetime.time):
+            if isinstance(value, dt.time):
                 return str(dt.Time(value))
             else:
                 return value
@@ -181,15 +181,15 @@ class XDateTime(XBuiltin):
     Represents an (xsd) xs:datetime builtin type.
     """
 
-    def translate(self, value, topython=True):
+    def translate(self, value, topython=True):	    
         if topython:
             if isinstance(value, basestring) and len(value):
-                return dt.DateTime(value).value
+                return DateTime(value).value
             else:
                 return None
         else:
-            if isinstance(value, datetime.datetime):
-                return str(dt.DateTime(value))
+            if isinstance(value, dt.datetime):
+                return str(DateTime(value))
             else:
                 return value
 


### PR DESCRIPTION
The following commit fixes issue #9 and also another problem related to DateTime usage