### PR TITLE
Check if root node is not none before appending

### DIFF
--- a/suds/sax/document.py
+++ b/suds/sax/document.py
@@ -44,7 +44,8 @@ class Document(Element):
         s = []
         s.append(self.DECL)
         s.append('\n')
-        s.append(self.root().str())
+        if self.root() is not None:
+            s.append(self.root().str())
         return ''.join(s)
 
     def plain(self):


### PR DESCRIPTION
This happens in a logging message so it has a low priority and does not need a release I think