### PR TITLE
fix to date conversion at sxbuiltin.py - Issue #7

### DIFF
--- a/suds/xsd/sxbuiltin.py
+++ b/suds/xsd/sxbuiltin.py
@@ -148,12 +148,12 @@ class XDate(XBuiltin):
     def translate(self, value, topython=True):
         if topython:
             if isinstance(value, basestring) and len(value):
-                return dt.Date(value).value
+                return dt.datetime.strptime(value, '%Y-%m-%d').date()
             else:
                 return None
         else:
             if isinstance(value, datetime.date):
-                return str(dt.Date(value))
+                return '{:%Y-%m-%d}'.format(value)
             else:
                 return value
 


### PR DESCRIPTION
I fixed the date conversion using suds in python3 because the datetime module doesn't have the Date method. It worked on my local machine and I started to using it.