### PR TITLE
python 2.7 compatibility

### DIFF
--- a/suds/bindings/__init__.py
+++ b/suds/bindings/__init__.py
@@ -18,3 +18,5 @@
 Provides modules containing classes to support Web Services (SOAP)
 bindings.
 """
+
+from __future__ import absolute_import, print_function, division, unicode_literals

--- a/suds/bindings/binding.py
+++ b/suds/bindings/binding.py
@@ -17,6 +17,7 @@
 """
 Provides classes for (WS) SOAP bindings.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import WebFault, TypeNotFound
@@ -38,7 +39,6 @@ from copy import deepcopy
 log = getLogger(__name__)
 
 envns = ('SOAP-ENV', 'http://schemas.xmlsoap.org/soap/envelope/')
-# envns = ('soapenv', 'http://schemas.xmlsoap.org/soap/envelope/')
 
 
 class Binding:

--- a/suds/bindings/document.py
+++ b/suds/bindings/document.py
@@ -17,6 +17,7 @@
 """
 Provides classes for the (WS) SOAP I{document/literal}.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.bindings.binding import Binding

--- a/suds/bindings/multiref.py
+++ b/suds/bindings/multiref.py
@@ -17,6 +17,7 @@
 """
 Provides classes for handling soap multirefs.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 

--- a/suds/builder.py
+++ b/suds/builder.py
@@ -17,6 +17,7 @@
 """
 The I{builder} module provides an wsdl/xsd defined types factory
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import TypeNotFound

--- a/suds/cache.py
+++ b/suds/cache.py
@@ -17,7 +17,9 @@
 """
 Contains basic caching classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
+import io
 import os
 import suds
 from tempfile import gettempdir as tmp
@@ -199,7 +201,7 @@ class FileCache(Cache):
     def putf(self, id, fp):
         try:
             fn = self.__fn(id)
-            f = self.open(fn, 'w')
+            f = self.open(fn, 'wb')
             f.write(fp.read())
             fp.close()
             f.close()
@@ -260,7 +262,7 @@ class FileCache(Cache):
         Open the cache file making sure the directory is created.
         """
         self.mktmp()
-        return open(fn, *args)
+        return io.open(fn, *args)
 
     def checkversion(self):
         path = os.path.join(self.location, 'version')
@@ -273,7 +275,7 @@ class FileCache(Cache):
                 raise Exception()
         except:
             self.clear()
-            f = self.open(path, 'w')
+            f = self.open(path, 'wb')
             f.write(suds.__version__)
             f.close()
 

--- a/suds/client.py
+++ b/suds/client.py
@@ -18,10 +18,17 @@
 The I{2nd generation} service proxy provides access to web services.
 See I{README.txt}
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
+
+
+try:
+    from http.cookiejar import CookieJar
+except ImportError:
+    from cookielib import CookieJar
+from copy import deepcopy
 
 import suds
 import suds.metrics as metrics
-from http.cookiejar import CookieJar
 from suds import (TypeNotFound, BuildError, ServiceNotFound, PortNotFound,
                   MethodNotFound, WebFault)
 from suds.reader import DefinitionsReader
@@ -37,7 +44,6 @@ from suds.cache import ObjectCache
 from suds.sax.parser import Parser
 from suds.options import Options
 from suds.properties import Unskin
-from copy import deepcopy
 from suds.plugin import PluginContainer
 from logging import getLogger
 

--- a/suds/metrics.py
+++ b/suds/metrics.py
@@ -18,6 +18,7 @@
 The I{metrics} module defines classes and other resources
 designed for collecting and reporting performance metrics.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 import time
 from logging import getLogger

--- a/suds/mx/__init__.py
+++ b/suds/mx/__init__.py
@@ -18,6 +18,7 @@
 Provides modules containing classes to support
 marshalling (XML).
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.sudsobject import Object
 

--- a/suds/mx/appender.py
+++ b/suds/mx/appender.py
@@ -17,6 +17,7 @@
 """
 Provides appender classes for I{marshalling}.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import null, tostr

--- a/suds/mx/basic.py
+++ b/suds/mx/basic.py
@@ -17,6 +17,7 @@
 """
 Provides basic I{marshaller} classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.mx import Content

--- a/suds/mx/core.py
+++ b/suds/mx/core.py
@@ -17,6 +17,7 @@
 """
 Provides I{marshaller} core classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.mx.appender import ContentAppender

--- a/suds/mx/encoded.py
+++ b/suds/mx/encoded.py
@@ -17,6 +17,7 @@
 """
 Provides encoded I{marshaller} classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import *

--- a/suds/mx/literal.py
+++ b/suds/mx/literal.py
@@ -17,6 +17,7 @@
 """
 Provides literal I{marshaller} classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import TypeNotFound, Object

--- a/suds/mx/typer.py
+++ b/suds/mx/typer.py
@@ -17,6 +17,7 @@
 """
 Provides sx typing classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import Object

--- a/suds/options.py
+++ b/suds/options.py
@@ -17,6 +17,7 @@
 """
 Suds basic options classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.properties import AutoLinker, Unskin, Skin, Definition
 from suds.wsse import Security

--- a/suds/plugin.py
+++ b/suds/plugin.py
@@ -18,6 +18,7 @@
 The plugin module provides classes for implementation
 of suds plugins.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 

--- a/suds/properties.py
+++ b/suds/properties.py
@@ -17,6 +17,7 @@
 """
 Properties classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from .utils import is_builtin

--- a/suds/reader.py
+++ b/suds/reader.py
@@ -17,6 +17,8 @@
 """
 Contains xml document reader classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
+
 import hashlib
 from logging import getLogger
 

--- a/suds/resolver.py
+++ b/suds/resolver.py
@@ -18,6 +18,7 @@
 The I{resolver} module provides a collection of classes that
 provide wsdl/xsd named type resolution.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 import re
 from logging import getLogger

--- a/suds/sax/__init__.py
+++ b/suds/sax/__init__.py
@@ -28,6 +28,7 @@ containing the prefix and the URI.  Eg: I{('tns', 'http://myns')}
     encode/decode strings.
 @type encoder: L{Encoder}
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.sax.enc import Encoder
 

--- a/suds/sax/attribute.py
+++ b/suds/sax/attribute.py
@@ -17,6 +17,7 @@
 """
 Provides XML I{attribute} classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.sax import Namespace, splitPrefix

--- a/suds/sax/document.py
+++ b/suds/sax/document.py
@@ -17,6 +17,7 @@
 """
 Provides XML I{document} classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.sax.element import Element

--- a/suds/sax/element.py
+++ b/suds/sax/element.py
@@ -17,6 +17,7 @@
 """
 Provides XML I{element} classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.compat import unicode, basestring

--- a/suds/sax/enc.py
+++ b/suds/sax/enc.py
@@ -17,6 +17,7 @@
 """
 Provides XML I{special character} encoder classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 import re
 

--- a/suds/sax/parser.py
+++ b/suds/sax/parser.py
@@ -25,6 +25,7 @@ XML namespaces in suds are represented using a (2) element tuple
 containing the prefix and the URI.  Eg: I{('tns', 'http://myns')}
 
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.compat import unicode

--- a/suds/sax/text.py
+++ b/suds/sax/text.py
@@ -17,11 +17,16 @@
 """
 Contains XML text classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds import sax
 
+try:
+    unicode = unicode
+except NameError:
+    unicode = str
 
-class Text(str):
+class Text(unicode):
     """
     An XML text object used to represent text content.
     @ivar lang: The (optional) language flag.

--- a/suds/servicedefinition.py
+++ b/suds/servicedefinition.py
@@ -17,6 +17,7 @@
 """
 The I{service definition} provides a textual representation of a service.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import tostr

--- a/suds/serviceproxy.py
+++ b/suds/serviceproxy.py
@@ -19,6 +19,7 @@ The service proxy provides access to web services.
 
 Replaced by: L{client.Client}
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 

--- a/suds/soaparray.py
+++ b/suds/soaparray.py
@@ -18,6 +18,7 @@
 The I{soaparray} module provides XSD extensions for handling
 soap (section 5) encoded arrays.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.xsd.sxbasic import Factory as SXFactory
 from suds.xsd.sxbasic import Attribute as SXAttribute

--- a/suds/store.py
+++ b/suds/store.py
@@ -19,6 +19,7 @@ Contains XML text for documents to be distributed
 with the suds lib.  Also, contains classes for accessing
 these documents.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from io import StringIO
 from logging import getLogger

--- a/suds/sudsobject.py
+++ b/suds/sudsobject.py
@@ -19,6 +19,7 @@ The I{sudsobject} module provides a collection of suds objects
 that are primarily used for the highly dynamic interactions with
 wsdl/xsd defined types.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 

--- a/suds/transport/__init__.py
+++ b/suds/transport/__init__.py
@@ -17,6 +17,7 @@
 """
 Contains transport interface (classes).
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 
 class TransportError(Exception):

--- a/suds/transport/http.py
+++ b/suds/transport/http.py
@@ -17,14 +17,24 @@
 """
 Contains classes for basic HTTP transport implementations.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
-import urllib.request as u2
-from urllib.error import HTTPError
+try:
+    import urllib.request as u2
+except ImportError:
+    import urllib2 as u2
+try:
+    from urllib.error import HTTPError
+except ImportError:
+    from urllib2 import HTTPError
 from base64 import b64encode
 import socket
 from suds.transport import Transport, TransportError, Reply
 from suds.properties import Unskin
-from http.cookiejar import CookieJar
+try:
+    from http.cookiejar import CookieJar
+except ImportError:
+    from cookielib import CookieJar
 from logging import getLogger
 
 log = getLogger(__name__)

--- a/suds/transport/https.py
+++ b/suds/transport/https.py
@@ -17,12 +17,19 @@
 """
 Contains classes for basic HTTP (authenticated) transport implementations.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
+
+try:
+    from urllib.request import (
+        HTTPPasswordMgrWithDefaultRealm,
+        HTTPBasicAuthHandler)
+except ImportError:
+    from urllib2 import (
+        HTTPPasswordMgrWithDefaultRealm,
+        HTTPBasicAuthHandler)
 
 from suds.transport.http import HttpTransport
 from logging import getLogger
-from urllib.request import (
-    HTTPPasswordMgrWithDefaultRealm,
-    HTTPBasicAuthHandler)
 
 log = getLogger(__name__)
 

--- a/suds/transport/options.py
+++ b/suds/transport/options.py
@@ -17,7 +17,7 @@
 """
 Contains classes for transport options.
 """
-
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.properties import Skin, Definition
 

--- a/suds/umx/__init__.py
+++ b/suds/umx/__init__.py
@@ -18,6 +18,7 @@
 Provides modules containing classes to support
 unmarshalling (XML).
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.sudsobject import Object
 

--- a/suds/umx/attrlist.py
+++ b/suds/umx/attrlist.py
@@ -17,6 +17,7 @@
 """
 Provides filtered attribute list classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.sax import Namespace
 

--- a/suds/umx/basic.py
+++ b/suds/umx/basic.py
@@ -17,6 +17,7 @@
 """
 Provides basic unmarshaller classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.umx import Content
 from suds.umx.core import Core

--- a/suds/umx/core.py
+++ b/suds/umx/core.py
@@ -17,6 +17,7 @@
 """
 Provides base classes for XML->object I{unmarshalling}.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.compat import basestring

--- a/suds/umx/encoded.py
+++ b/suds/umx/encoded.py
@@ -17,6 +17,7 @@
 """
 Provides soap encoded unmarshaller classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.umx import Content

--- a/suds/umx/typed.py
+++ b/suds/umx/typed.py
@@ -17,6 +17,7 @@
 """
 Provides typed unmarshaller classes.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import TypeNotFound

--- a/suds/utils.py
+++ b/suds/utils.py
@@ -1,3 +1,0 @@
-
-def is_builtin(name):
-    return name.startswith('__') and name.endswith('__')

--- a/suds/wsdl.py
+++ b/suds/wsdl.py
@@ -19,6 +19,7 @@ The I{wsdl} module provides an objectification of the WSDL.
 The primary class is I{Definitions} as it represends the root element
 found in the document.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import objid, TypeNotFound, MethodNotFound
@@ -30,7 +31,10 @@ from suds.xsd.schema import Schema, SchemaCollection
 from suds.xsd.query import ElementQuery
 from suds.sudsobject import Object, Facade, Metadata
 from suds.reader import DocumentReader
-from urllib.parse import urljoin
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 import re
 
 log = getLogger(__name__)

--- a/suds/wsse.py
+++ b/suds/wsse.py
@@ -17,6 +17,7 @@
 """
 The I{wsse} module provides WS-Security.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds.sudsobject import Object
 from suds.sax.element import Element

--- a/suds/xsd/__init__.py
+++ b/suds/xsd/__init__.py
@@ -21,6 +21,7 @@ is the denormalized, objectified and intelligent view of the schema.
 Most of the I{value-add} provided by the model is centered around
 tranparent referenced type resolution and targeted denormalization.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.compat import basestring

--- a/suds/xsd/deplist.py
+++ b/suds/xsd/deplist.py
@@ -17,6 +17,7 @@
 """
 The I{depsolve} module defines a class for performing dependancy solving.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 

--- a/suds/xsd/doctor.py
+++ b/suds/xsd/doctor.py
@@ -18,6 +18,7 @@
 The I{doctor} module provides classes for fixing broken (sick)
 schema(s).
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.sax import Namespace

--- a/suds/xsd/query.py
+++ b/suds/xsd/query.py
@@ -17,6 +17,7 @@
 """
 The I{query} module defines a class for performing schema queries.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import Object, Repr, objid, tostr

--- a/suds/xsd/schema.py
+++ b/suds/xsd/schema.py
@@ -21,7 +21,7 @@ is the denormalized, objectified and intelligent view of the schema.
 Most of the I{value-add} provided by the model is centered around
 tranparent referenced type resolution and targeted denormalization.
 """
-
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds import objid, Repr
 from suds.xsd import isqref

--- a/suds/xsd/sxbase.py
+++ b/suds/xsd/sxbase.py
@@ -18,6 +18,7 @@
 The I{sxbase} module provides I{base} classes that represent
 schema objects.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds import objid, Repr

--- a/suds/xsd/sxbasic.py
+++ b/suds/xsd/sxbasic.py
@@ -18,6 +18,7 @@
 The I{sxbasic} module provides classes that represent
 I{basic} schema objects.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from suds import *
 from suds.xsd import *
@@ -26,7 +27,10 @@ from suds.xsd.query import *
 from suds.sax import splitPrefix, Namespace
 from suds.transport import TransportError
 from suds.reader import DocumentReader
-from urllib.parse import urljoin
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 
 
 log = getLogger(__name__)

--- a/suds/xsd/sxbuiltin.py
+++ b/suds/xsd/sxbuiltin.py
@@ -18,6 +18,7 @@
 The I{sxbuiltin} module provides classes that represent
 XSD I{builtin} schema objects.
 """
+from __future__ import absolute_import, print_function, division, unicode_literals
 
 from logging import getLogger
 from suds.compat import basestring

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the (LGPL) GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the 
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Lesser General Public License for more details at
+# ( http://www.gnu.org/licenses/lgpl.html ).
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# written by: Jeff Ortel ( jortel@redhat.com )
+from __future__ import absolute_import, print_function, division, unicode_literals


### PR DESCRIPTION
from __future__ import in order to make python 2 behave more like python3
added proper imports to make it work in both py2 and py3
fixed some str/unicode issue in a way that will work in both py2 and py3