### PR TITLE
& character escaped in all cases

### DIFF
--- a/suds/sax/enc.py
+++ b/suds/sax/enc.py
@@ -33,7 +33,7 @@ class Encoder:
     """
 
     encodings = (
-        ('&(?!(amp|lt|gt|quot|apos);)', '&amp;'),
+        ('&', '&amp;'),
         ('<', '&lt;'),
         ('>', '&gt;'),
         ('"', '&quot;'),


### PR DESCRIPTION
Pull request for bug #33 
& character should be escaped in all cases also if data contains: `&amp; &lt; &gt; &quot; &apos;`

For example `&lt;test&gt;` should be escaped to `&amp;lt;test&amp;gt; `- more information in the ticket description.
