### PR TITLE
fix issue #37 regarding method location

### DIFF
--- a/suds/client.py
+++ b/suds/client.py
@@ -104,7 +104,6 @@ class Client(object):
         options = Options()
         options.transport = HttpAuthenticated()
         self.options = options
-        self.options.location = url
         options.cache = ObjectCache(days=1)
         self.set_options(**kwargs)
         reader = DefinitionsReader(options, Definitions)
@@ -729,7 +728,7 @@ class SoapClient:
 
     def location(self):
         p = Unskin(self.options)
-        return p.get('location', self.method.location)
+        return p.get('location', self.method.location.decode('utf-8'))
 
     def last_sent(self, d=None):
         key = 'tx'


### PR DESCRIPTION
this issue happens when the method location/url is different to wsdl location/url.  
suds client always takes the wsdl location/url and not the method location so when making a request it uses wrong location getting invalid response hence causing this issue.
by the way suds python2 library doesn't have line 107 therefore it works fine.
