### PR TITLE
Resolves issue #45 fix required as result of change in #40

### DIFF
--- a/suds/wsdl.py
+++ b/suds/wsdl.py
@@ -857,7 +857,7 @@ class Service(NamedObject):
         for p in self.ports:
             for m in p.methods.values():
                 if names is None or m.name in names:
-                    m.location = url
+                    m.location = url.encode('utf-8')
 
     def resolve(self, definitions):
         """


### PR DESCRIPTION
Ensure that wsdl.py  Service.setLocation() stores encoded value compatible with those set directly in the __init__ method from the WSDL, and ready to be decoded by the change at #40/#37