### PR TITLE
& character escaped in all cases

### DIFF
--- a/suds/sax/enc.py
+++ b/suds/sax/enc.py
@@ -33,7 +33,7 @@ class Encoder:
     """
 
     encodings = (
-        ('&(?!(amp|lt|gt|quot|apos);)', '&amp;'),
+        ('&', '&amp;'),
         ('<', '&lt;'),
         ('>', '&gt;'),
         ('"', '&quot;'),

--- a/tests/encode_specials_test.py
+++ b/tests/encode_specials_test.py
@@ -6,5 +6,4 @@ class TestEncodeSpecials(unittest.TestCase):
     def test_specials_chars(self):
         encoder = suds.sax.Encoder()
         assert encoder.needsEncoding('&lt;test') == True # output is True
-        print(encoder.encode('&lt;test'))
         assert encoder.encode('&lt;test') == '&amp;lt;test'

--- a/tests/encode_specials_test.py
+++ b/tests/encode_specials_test.py
@@ -1,0 +1,10 @@
+import unittest
+
+import suds
+
+class TestEncodeSpecials(unittest.TestCase):
+    def test_specials_chars(self):
+        encoder = suds.sax.Encoder()
+        assert encoder.needsEncoding('&lt;test') == True # output is True
+        print(encoder.encode('&lt;test'))
+        assert encoder.encode('&lt;test') == '&amp;lt;test'


### PR DESCRIPTION
Pull request for bug #33
& character should be escaped in all cases also if data contains: &amp; &lt; &gt; &quot; &apos;

For example &lt;test&gt; should be escaped to &amp;lt;test&amp;gt; - more information in the ticket description.