### PR TITLE
Replaced md5 with sha256

### DIFF
--- a/suds/reader.py
+++ b/suds/reader.py
@@ -49,7 +49,7 @@ class Reader:
         Mangle the name by hashing the I{name} and appending I{x}.
         @return: the mangled name.
         """
-        h = hashlib.md5(name.encode('utf8')).hexdigest()
+        h = hashlib.sha256(name.encode('utf8')).hexdigest()
         return '%s-%s' % (h, x)
 
 

--- a/suds/wsse.py
+++ b/suds/wsse.py
@@ -24,10 +24,11 @@ from suds.sax.date import DateTime, UtcTimezone
 from datetime import datetime, timedelta
 
 try:
-    from hashlib import md5
+    from hashlib import sha256
 except ImportError:
     # Python 2.4 compatibility
-    from md5 import md5
+    from md5 import md5 as sha56
+
 
 
 dsns = ('ds', 'http://www.w3.org/2000/09/xmldsig#')
@@ -139,7 +140,7 @@ class UsernameToken(Token):
             s.append(self.username)
             s.append(self.password)
             s.append(Token.sysdate())
-            m = md5()
+            m = sha56()
             m.update(':'.join(s).encode("utf-8"))
             self.nonce = m.hexdigest()
         else:


### PR DESCRIPTION
Replaced md5 algo with sha256. This solves issue #57 .
For python 2.4 sha256 is not available. As workaround md5 is still used there.