### PR TITLE
Copy python 2.4 fix from suds-jurko

### DIFF
--- a/suds/cache.py
+++ b/suds/cache.py
@@ -30,6 +30,7 @@ try:
     import cPickle as pickle
 except:
     import pickle
+import shutil
 
 log = getLogger(__name__)
 
@@ -321,7 +322,11 @@ class FileCache(Cache):
 
         """
         if FileCache.remove_default_location_on_exit:
-            import shutil
+            # We must not load shutil here on-demand as under some
+            # circumstances this may cause the shutil.rmtree() operation to
+            # fail due to not having some internal module loaded. E.g. this
+            # happens if you run the project's test suite using the setup.py
+            # test command on Python 2.4.x.
             shutil.rmtree(FileCache.__default_location, ignore_errors=True)
 
 


### PR DESCRIPTION
Sorry, missed this earlier. Not sure if this causes issues in any modern versions of Python but the suds-jurko and suds-community forks have this fix as well.

Follow up to #71 