### PR TITLE
Use correct Object to support ordering

### DIFF
--- a/suds/mx/literal.py
+++ b/suds/mx/literal.py
@@ -19,13 +19,13 @@ Provides literal I{marshaller} classes.
 """
 
 from logging import getLogger
-from suds import TypeNotFound, Object
+from suds import TypeNotFound
 from suds.mx import Content
 from suds.mx.core import Core
 from suds.mx.typer import Typer
 from suds.resolver import GraphResolver, Frame
 from suds.sax.element import Element
-from suds.sudsobject import Factory
+from suds.sudsobject import Factory, Object
 
 log = getLogger(__name__)
 


### PR DESCRIPTION
In the Python 2 version mx/literal.py contains this:

```
from suds import *
from suds.mx import *
```
And mx/__init__.py contains this:

`from suds.sudsobject import Object`
So in the end it will be suds.sudsobject.Object which gets used.

In the Python 3 version __init__.py has introduced this:

```
class Object(object):
    """
    The python 3 base Object
    """
    pass
```
And mx/literal.py now instead has this:

`from suds import TypeNotFound, Object`
So indeed it is importing the wrong Object class in Python 3.